### PR TITLE
Fix #232 ConfigBuilder isn't commutative

### DIFF
--- a/Soomla/config/CCSoomlaFacebookConfigBuilder.cpp
+++ b/Soomla/config/CCSoomlaFacebookConfigBuilder.cpp
@@ -30,6 +30,10 @@ CCSoomlaFacebookConfigBuilder *CCSoomlaFacebookConfigBuilder::create() {
     return new CCSoomlaFacebookConfigBuilder();
 }
 
+CCSoomlaFacebookConfigBuilder *CCSoomlaFacebookConfigBuilder::enableAutoLogin(bool enabled) {
+    return (CCSoomlaFacebookConfigBuilder *)CCSoomlaProfileSNConfigBuilder::enableAutoLogin(enabled);
+}
+
 CCSoomlaFacebookConfigBuilder *CCSoomlaFacebookConfigBuilder::setPermissions(const char *permissions) {
     return this->appendConfigParameter("permissions", cocos2d::__String::create(permissions)) ? this : NULL;
 }

--- a/Soomla/config/CCSoomlaFacebookConfigBuilder.h
+++ b/Soomla/config/CCSoomlaFacebookConfigBuilder.h
@@ -25,6 +25,7 @@ namespace soomla {
         CCSoomlaFacebookConfigBuilder();
         CCProvider getProvider();
         static CCSoomlaFacebookConfigBuilder *create();
+        CCSoomlaFacebookConfigBuilder *enableAutoLogin(bool enabled);
         CCSoomlaFacebookConfigBuilder *setPermissions(const char *permissions);
     };
 }

--- a/Soomla/config/CCSoomlaGameCenterConfigBuilder.cpp
+++ b/Soomla/config/CCSoomlaGameCenterConfigBuilder.cpp
@@ -33,4 +33,8 @@ CCSoomlaGameCenterConfigBuilder *CCSoomlaGameCenterConfigBuilder::create() {
     return new CCSoomlaGameCenterConfigBuilder();
 }
 
+CCSoomlaGameCenterConfigBuilder *CCSoomlaGameCenterConfigBuilder::enableAutoLogin(bool enabled) {
+    return (CCSoomlaGameCenterConfigBuilder *)CCSoomlaProfileSNConfigBuilder::enableAutoLogin(enabled);
+}
+
 #endif

--- a/Soomla/config/CCSoomlaGameCenterConfigBuilder.h
+++ b/Soomla/config/CCSoomlaGameCenterConfigBuilder.h
@@ -27,6 +27,7 @@ namespace soomla {
     public:
         CCSoomlaGameCenterConfigBuilder();
         CCProvider getProvider();
+        CCSoomlaGameCenterConfigBuilder *enableAutoLogin(bool enabled);
         static CCSoomlaGameCenterConfigBuilder *create();
     };
 }

--- a/Soomla/config/CCSoomlaGooglePlusConfigBuilder.cpp
+++ b/Soomla/config/CCSoomlaGooglePlusConfigBuilder.cpp
@@ -30,6 +30,10 @@ CCSoomlaGooglePlusConfigBuilder *CCSoomlaGooglePlusConfigBuilder::create() {
     return new CCSoomlaGooglePlusConfigBuilder();
 }
 
+CCSoomlaGooglePlusConfigBuilder *CCSoomlaGooglePlusConfigBuilder::enableAutoLogin(bool enabled) {
+    return (CCSoomlaGooglePlusConfigBuilder *)CCSoomlaProfileSNConfigBuilder::enableAutoLogin(enabled);
+}
+
 CCSoomlaGooglePlusConfigBuilder *CCSoomlaGooglePlusConfigBuilder::setClientId(const char *clientId) {
     return this->appendConfigParameter("clientId", cocos2d::__String::create(clientId)) ? this : NULL;
 }

--- a/Soomla/config/CCSoomlaGooglePlusConfigBuilder.h
+++ b/Soomla/config/CCSoomlaGooglePlusConfigBuilder.h
@@ -25,6 +25,7 @@ namespace soomla {
         CCSoomlaGooglePlusConfigBuilder();
         CCProvider getProvider();
         static CCSoomlaGooglePlusConfigBuilder *create();
+        CCSoomlaGooglePlusConfigBuilder *enableAutoLogin(bool enabled);
         CCSoomlaGooglePlusConfigBuilder *setClientId(const char *clientId);
         CCSoomlaGooglePlusConfigBuilder *enableGameServices(bool enableGameServices);
     };

--- a/Soomla/config/CCSoomlaProfileSNConfigBuilder.h
+++ b/Soomla/config/CCSoomlaProfileSNConfigBuilder.h
@@ -26,7 +26,7 @@ namespace soomla {
         CCSoomlaProfileSNConfigBuilder();
         virtual CCProvider getProvider() = 0;
         static CCSoomlaProfileSNConfigBuilder *create();
-        CCSoomlaProfileSNConfigBuilder *enableAutoLogin(bool enabled);
+        virtual CCSoomlaProfileSNConfigBuilder *enableAutoLogin(bool enabled);
     };
 }
 

--- a/Soomla/config/CCSoomlaTwitterConfigBuilder.cpp
+++ b/Soomla/config/CCSoomlaTwitterConfigBuilder.cpp
@@ -30,6 +30,10 @@ CCSoomlaTwitterConfigBuilder *CCSoomlaTwitterConfigBuilder::create() {
     return new CCSoomlaTwitterConfigBuilder();
 }
 
+CCSoomlaTwitterConfigBuilder *CCSoomlaTwitterConfigBuilder::enableAutoLogin(bool enabled) {
+    return (CCSoomlaTwitterConfigBuilder *)CCSoomlaProfileSNConfigBuilder::enableAutoLogin(enabled);
+}
+
 CCSoomlaTwitterConfigBuilder *CCSoomlaTwitterConfigBuilder::setConsumerKey(const char *consumerKey) {
     return this->appendConfigParameter("consumerKey", cocos2d::__String::create(consumerKey)) ? this : NULL;
 }

--- a/Soomla/config/CCSoomlaTwitterConfigBuilder.h
+++ b/Soomla/config/CCSoomlaTwitterConfigBuilder.h
@@ -25,6 +25,7 @@ namespace soomla {
         CCSoomlaTwitterConfigBuilder();
         CCProvider getProvider();
         static CCSoomlaTwitterConfigBuilder *create();
+        CCSoomlaTwitterConfigBuilder *enableAutoLogin(bool enabled);
         CCSoomlaTwitterConfigBuilder *setConsumerKey(const char *consumerKey);
         CCSoomlaTwitterConfigBuilder *setConsumerSecret(const char *setConsumerSecret);
     };


### PR DESCRIPTION
Related issue: https://answers.soom.la/t/profile-config-builders-cant-hold-more-than-one-key/4830